### PR TITLE
Stop VariableResolutionFingerprintReader add end of record instead of…

### DIFF
--- a/src/main/java/org/jnbis/internal/record/reader/VariableResolutionFingerprintReader.java
+++ b/src/main/java/org/jnbis/internal/record/reader/VariableResolutionFingerprintReader.java
@@ -120,6 +120,10 @@ public class VariableResolutionFingerprintReader extends RecordReader {
                 default:
                     break;
             }
+
+            if (token.buffer[token.pos++] == NistHelper.SEP_FS) {
+                break;
+            }
         }
 
         return fingerprint;


### PR DESCRIPTION
… when 14.999 is found.
In the NIST ITL-2011 Update:2013 field 14.999 is optional, while in the code it was mandatory. 
The code was update to break on the record separator when no fields can be found anymore.