### PR TITLE
Updated to add additional metadata to high resolution grayscale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/.settings/

--- a/src/main/java/org/jnbis/internal/record/reader/HighResolutionGrayscaleFingerprintReader.java
+++ b/src/main/java/org/jnbis/internal/record/reader/HighResolutionGrayscaleFingerprintReader.java
@@ -1,7 +1,9 @@
 package org.jnbis.internal.record.reader;
 
-import org.jnbis.internal.NistHelper;
+import java.util.Arrays;
+
 import org.jnbis.api.model.record.HighResolutionGrayscaleFingerprint;
+import org.jnbis.internal.NistHelper;
 
 /**
  * @author ericdsoto
@@ -18,8 +20,47 @@ public class HighResolutionGrayscaleFingerprintReader extends RecordReader {
 
         //Assigning t4-Header values
         Integer length = (int) readInt(token);
+        
+        //Refer to manual for byte positions:
+        //https://www.nist.gov/sites/default/files/documents/itl/ansi/sp500-245-a16.pdf
+        
+        // Finger position (FGP)
         int fingerPrintNo = token.buffer[token.pos + 6];
 
+        //Impression type (IMP)
+        int imp = token.buffer[token.pos + 5];
+        fingerprint.setImpressionType(String.valueOf(imp));
+        
+        //Image designation character (IDC)
+        int idc = token.buffer[token.pos + 4];
+        fingerprint.setImageDesignationCharacter(String.valueOf(idc));
+        
+        // Image scanning resolution (ISR)
+        int isr = token.buffer[token.pos + 12];
+        fingerprint.setImageScanningResolution(String.valueOf(isr));
+        
+        //Grayscale compression algorithm (GCA)
+        int gca = token.buffer[token.pos + 17];
+        fingerprint.setCompressionAlgorithm(String.valueOf(gca));
+        
+        //Horizontal line length (HLL)
+        byte[] slice = Arrays.copyOfRange(token.buffer, token.pos + 13, token.pos + 15);
+        Long hll = byteToInt(slice, 2);
+
+        if (hll != null)
+        {	
+        	fingerprint.setHorizontalLineLength(String.valueOf(hll));
+        }	
+
+        //Vertical line length (VLL)
+        slice = Arrays.copyOfRange(token.buffer, token.pos + 15, token.pos + 17);
+        Long vll = byteToInt(slice, 2);
+        
+        if (vll != null)
+        {	
+        	fingerprint.setVerticalLineLength(String.valueOf(vll));
+        }	
+        	
         int dataSize = length - 18;
 
         if (token.pos + dataSize + 17 > token.buffer.length) {
@@ -35,5 +76,16 @@ public class HighResolutionGrayscaleFingerprintReader extends RecordReader {
         fingerprint.setLogicalRecordLength(length.toString());
 
         return fingerprint;
+    }
+    
+    /** length should be less than 4 (for int) **/
+    public long byteToInt(byte[] bytes, int length) {
+            int val = 0;
+            if(length>4) throw new RuntimeException("Too big to fit in int");
+            for (int i = 0; i < length; i++) {
+                val=val<<8;
+                val=val|(bytes[i] & 0xFF);
+            }
+            return val;
     }
 }

--- a/src/test/java/org/jnbis/SampleNistTest.java
+++ b/src/test/java/org/jnbis/SampleNistTest.java
@@ -41,6 +41,16 @@ public class SampleNistTest {
             String fileName = findFileName(fingerPrint.getImageDesignationCharacter());
 
             Assert.assertArrayEquals(FileUtils.read(new File(fileName)), pngArray);
+            
+            if (fingerPrint.getImageDesignationCharacter().equals("1"))
+            {
+            	Assert.assertEquals("3", fingerPrint.getImpressionType());
+            	Assert.assertEquals("1", fingerPrint.getImageDesignationCharacter());
+            	Assert.assertEquals("0", fingerPrint.getImageScanningResolution());
+            	Assert.assertEquals("1", fingerPrint.getCompressionAlgorithm());
+            	Assert.assertEquals("804", fingerPrint.getHorizontalLineLength());
+            	Assert.assertEquals("752", fingerPrint.getVerticalLineLength());
+            }	
         }
     }
 


### PR DESCRIPTION
The high resolution grayscale reader provided some basic metadata.  However, some NIST submissions have required metadata that must be submitted with fingerprints.  Updated fingerprint with this metadata and updated NIST unit test. Updated git ignore.